### PR TITLE
Modernize library

### DIFF
--- a/Control/RateLimit.hs
+++ b/Control/RateLimit.hs
@@ -42,7 +42,7 @@ module Control.RateLimit(
 
 import Control.Concurrent
 import Control.Concurrent.STM
-import Control.Monad(when)
+import Control.Monad(void, when)
 import Data.Functor(($>))
 import Data.Time.Units
 
@@ -114,7 +114,7 @@ generateRateLimitedFunction :: forall req resp t.
   -> IO (req -> IO resp)
 generateRateLimitedFunction ratelimit action combiner
   = do chan <- atomically newTChan
-       forkIO $ runner (-42) chan
+       void $ forkIO $ runner (-42) chan
        return $ resultFunction chan
  where
   currentMicros :: IO Integer

--- a/Control/RateLimit.hs
+++ b/Control/RateLimit.hs
@@ -44,7 +44,7 @@ import Control.Monad(when)
 import Data.Time.Units
 
 -- |The rate at which to limit an action.
-data TimeUnit a => RateLimit a =
+data RateLimit a =
     PerInvocation a -- ^Rate limit the action to invocation once per time
                     --  unit. With this option, the time it takes for the
                     --  action to take place is not taken into consideration

--- a/rate-limit.cabal
+++ b/rate-limit.cabal
@@ -17,7 +17,9 @@ Description:
   is intended as a general-purpose mechanism for rate-limiting IO actions. 
 
 Library
-  Build-Depends: base >= 4.0 && < 5.0, time-units >= 1.0 && < 2.0
+  Build-Depends: base       >= 4.0 && < 5.0
+               , stm        >= 2.4 && < 2.5
+               , time-units >= 1.0 && < 2.0
   Exposed-Modules: Control.RateLimit
 
 source-repository head


### PR DESCRIPTION
Hi Adam,

Thanks for this library!

I needed to make some changes to `Control.RateLimit` for my own purposes (i.e. to take `MonadIO m` instead of `IO` actions), but had to bring things up-to-date first before I could do that.

The two major changes I made were to:
- remove the use of a datatype context on `RateLimit a`
- switch from `Chan` to `TChan` due to `unGetChan` and `isEmptyChan` now being deprecated (see http://ghc.haskell.org/trac/ghc/ticket/4154). This adds a dependency on `stm`.

Before making my own (`MonadIO`) changes, I also took the liberty to reformat the module to try to reflect more recent Galois code on GitHub (at least as far as I could gather :). The reformatting occurs in the last commit in this PR if you'd prefer to drop that change.

If you'd happen to be interested in a version of `Control.RateLimit` that deals in `MonadIO m` instead of `IO` (using [`monadIO`](https://github.com/GaloisInc/monadIO)), then let me know and I can open another PR.

Thanks,
Brian