### PR TITLE
Improvements to timing accuracy

### DIFF
--- a/Control/RateLimit.hs
+++ b/Control/RateLimit.hs
@@ -141,11 +141,11 @@ generateRateLimitedFunction ratelimit action combiner = do
     let baseHandler resp = putMVar respMV resp
     -- can we combine this with any other requests on the pipe?
     (req', finalHandler) <- updateRequestWithFollowers chan req baseHandler
+    beforeRun <- currentMicroseconds
     if shouldFork ratelimit
       then forkIO (action req' >>= finalHandler) >> return ()
       else action req' >>= finalHandler
-    nextTime <- currentMicroseconds
-    runner nextTime chan
+    runner beforeRun chan
 
   -- updateRequestWithFollowers: We have one request. Can we combine it with
   -- some other requests into a cohesive whole?

--- a/rate-limit.cabal
+++ b/rate-limit.cabal
@@ -17,9 +17,10 @@ Description:
   is intended as a general-purpose mechanism for rate-limiting IO actions. 
 
 Library
-  Build-Depends: base       >= 4.0 && < 5.0
-               , stm        >= 2.4 && < 2.5
-               , time-units >= 1.0 && < 2.0
+  Build-Depends: base       >= 4.0     && < 5.0
+               , stm        >= 2.4     && < 2.5
+               , time-units >= 1.0     && < 2.0
+               , time       >= 1.5.0.1 && < 1.9
   Exposed-Modules: Control.RateLimit
 
 source-repository head


### PR DESCRIPTION
Hi Adam,

Here are a few changes I've found bring rate-limited actions closer to the target rate limit.

Before when I was using `PerExecution` and tried to do e.g. 500 HTTP requests per second, I would only get ~300/sec. With `PerInvocation` I would get around ~310/sec. After these changes, using either method, I get ~495/sec.

These changes:
- Use elapsed total/system clock time instead of elapsed CPU time. This adds a dependency on the `time` package.
- Use the time *before* the last run, not after, to calculate sleep time. This is important for `PerExecution` when `IO` actions take a nontrivial amount of time.
- Calculate by how much time `threadDelay` has overslept, and discount that extra time from future sleeps.

Let me know if you have any questions, or if there's anything I can change.

Thanks!
Brian