### PR TITLE
Bumb upper bound on time and version

### DIFF
--- a/rate-limit.cabal
+++ b/rate-limit.cabal
@@ -1,5 +1,5 @@
 Name: rate-limit
-Version: 1.4.1
+Version: 1.4.2
 Build-Type: Simple
 Cabal-Version: >= 1.6
 License: BSD3
@@ -20,7 +20,7 @@ Library
   Build-Depends: base       >= 4.0     && < 5.0
                , stm        >= 2.4     && < 2.6
                , time-units >= 1.0     && < 2.0
-               , time       >= 1.5.0.1 && < 1.9
+               , time       >= 1.5.0.1 && < 1.10
   Exposed-Modules: Control.RateLimit
 
 source-repository head


### PR DESCRIPTION
Current version of time is 1.9.0 and it seems to work fine with this.
Also the changelog of time contains no hints to necessary changes.