### PR TITLE
Require Cabal 1.8+

### DIFF
--- a/rate-limit.cabal
+++ b/rate-limit.cabal
@@ -1,7 +1,7 @@
 Name: rate-limit
 Version: 1.4.2
 Build-Type: Simple
-Cabal-Version: >= 1.6
+Cabal-Version: >= 1.8
 License: BSD3
 License-File: LICENSE
 Author: Adam Wick <awick@uhsure.com>


### PR DESCRIPTION
Fixes the warning:
```
Warning: rate-limit.cabal:20:42: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```